### PR TITLE
https 통신으로 변경

### DIFF
--- a/src/main/java/com/example/beside/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/beside/common/config/SwaggerConfig.java
@@ -26,7 +26,7 @@ public class SwaggerConfig {
         public OpenAPI customOpenAPI() {
                 return new OpenAPI()
                                 .servers(Arrays.asList(
-                                                new Server().url("http://moim.life/").description("Production server"),
+                                                new Server().url("https://moim.life/").description("Production server"),
                                                 new Server().url("http://localhost:8081").description("local server")))
                                 .info(new Info().title("b-side")
                                                 .description("API documentation using springdoc-openapi and OpenAPI 3.0")


### PR DESCRIPTION
백엔드 서버의 기본 통신을 https 강제합니다.
Swagger 에서 Let's encrypt SSL인증서를 발급받고 HTTPS 통신으로 redirect 시킵니다,
