### PR TITLE
닉네임 중복 검사 소셜타입 조건 추가

### DIFF
--- a/src/main/java/com/example/beside/api/user/UserController.java
+++ b/src/main/java/com/example/beside/api/user/UserController.java
@@ -157,6 +157,7 @@ public class UserController {
         User updateUser = new User();
         updateUser.setId(user.getId());
         updateUser.setName(request.name);
+        updateUser.setSocial_type(user.getSocial_type());
 
         String newNickname = userService.updateNickname(updateUser);
 

--- a/src/main/java/com/example/beside/repository/UserRepository.java
+++ b/src/main/java/com/example/beside/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.example.beside.repository;
 
+import com.example.beside.domain.LoginType;
 import com.example.beside.domain.QUser;
 import com.example.beside.domain.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -109,11 +110,14 @@ public class UserRepository {
         return queryFactory.selectFrom(qUser).where(qUser.id.eq(user.getId())).fetchOne();
     }
 
-    public Optional<User> findUserNickname(String nickname) {
+    public Optional<User> findUserNicknameByMoim(String nickname) {
         queryFactory = new JPAQueryFactory(em);
         QUser qUser = new QUser("u");
 
-        User result = queryFactory.selectFrom(qUser).where(qUser.name.eq(nickname)).fetchOne();
+        User result = queryFactory.selectFrom(qUser)
+                .where(qUser.name.eq(nickname)
+                        .and(qUser.social_type.eq(LoginType.MOIM.name())))
+                .fetchOne();
 
         return Optional.ofNullable(result);
     }

--- a/src/main/java/com/example/beside/service/UserService.java
+++ b/src/main/java/com/example/beside/service/UserService.java
@@ -13,6 +13,7 @@ import com.example.beside.util.PasswordConverter;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.util.Optionals;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,10 +87,13 @@ public class UserService {
     @Transactional
     public String updateNickname(User user) throws Exception {
         String nickname = user.getName();
-        Optional<User> optionalUser = userRepository.findUserNickname(nickname);
-        if (optionalUser.isPresent()) {
-            throw new IllegalStateException("중복된 닉네임입니다.");
+        if(user.getSocial_type().equals("MOIM")) {
+            Optional<User> optionalUser = userRepository.findUserNicknameByMoim(nickname);
+            if (optionalUser.isPresent()) {
+                throw new IllegalStateException("중복된 닉네임입니다.");
+            }
         }
+
         Common.NicknameValidate(nickname);
 
         User updateUserInfo = userRepository.updateNickname(user);

--- a/src/test/java/com/example/beside/service/UserServiceTest.java
+++ b/src/test/java/com/example/beside/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.beside.service;
 
 import com.example.beside.common.Exception.UserValidateNickName;
+import com.example.beside.domain.LoginType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -68,6 +69,7 @@ public class UserServiceTest {
 
         user7.setEmail("test_678@naver.com");
         user7.setName("은지");
+        user7.setSocial_type(LoginType.MOIM.name());
         user7.setPassword("wd!2awQWDas!@");
     }
 
@@ -217,10 +219,11 @@ public class UserServiceTest {
     }
 
     @Test
-    @DisplayName("중복 닉네임")
-    void testUpdateNickNameDuplication() throws PasswordException {
+    @DisplayName("소셜타입이 모임일 경우 중복 닉네임")
+    void testUpdateMoimNickNameDuplication() throws PasswordException {
         // given
         userService.saveUser(user7);
+
         // when, then
         assertThrows(IllegalStateException.class, () -> userService.updateNickname(user7));
     }


### PR DESCRIPTION
닉네임 수정 전 자체 회원가입 계정인지 확인 후 닉네임 중복 검사를 진행합니다.