### PR TITLE
닉네임 중복검사 제거 및 특수문자 등록 가능

### DIFF
--- a/src/main/java/com/example/beside/api/user/UserController.java
+++ b/src/main/java/com/example/beside/api/user/UserController.java
@@ -150,8 +150,7 @@ public class UserController {
     @Operation(tags = { "User" }, summary = "닉네임변경")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "닉네임이 변경 되었습니다."),
-            @ApiResponse(responseCode = "400", description = "한글, 영문, 숫자 조합 8자 이내"),
-            @ApiResponse(responseCode = "500", description = "중복된 닉네임 입니다.") })
+            @ApiResponse(responseCode = "400", description = "닉네임은 8자 이내여야 합니다.")})
     @PutMapping(value = "/v1/update/nickname")
     public Response<String> updateNickname(HttpServletRequest token,
             @RequestBody @Validated UpdateUserNicknameRequest request)

--- a/src/main/java/com/example/beside/repository/UserRepository.java
+++ b/src/main/java/com/example/beside/repository/UserRepository.java
@@ -110,13 +110,12 @@ public class UserRepository {
         return queryFactory.selectFrom(qUser).where(qUser.id.eq(user.getId())).fetchOne();
     }
 
-    public Optional<User> findUserNicknameByMoim(String nickname) {
+    public Optional<User> findUserNickname(String nickname) {
         queryFactory = new JPAQueryFactory(em);
         QUser qUser = new QUser("u");
 
         User result = queryFactory.selectFrom(qUser)
-                .where(qUser.name.eq(nickname)
-                        .and(qUser.social_type.eq(LoginType.MOIM.name())))
+                .where(qUser.name.eq(nickname))
                 .fetchOne();
 
         return Optional.ofNullable(result);

--- a/src/main/java/com/example/beside/service/UserService.java
+++ b/src/main/java/com/example/beside/service/UserService.java
@@ -42,10 +42,6 @@ public class UserService {
 
         // 닉네임 검증
         Common.NicknameValidate(user.getName());
-        Optional<User> findNickname = userRepository.findUserNicknameByMoim(user.getName());
-        if (findNickname.isPresent()) {
-            throw new IllegalStateException("중복된 닉네임입니다.");
-        }
 
         return userRepository.saveUser(user);
     }
@@ -96,12 +92,6 @@ public class UserService {
     @Transactional
     public String updateNickname(User user) throws Exception {
         String nickname = user.getName();
-        if (user.getSocial_type().equals("MOIM")) {
-            Optional<User> optionalUser = userRepository.findUserNicknameByMoim(nickname);
-            if (optionalUser.isPresent()) {
-                throw new IllegalStateException("중복된 닉네임입니다.");
-            }
-        }
 
         Common.NicknameValidate(nickname);
 

--- a/src/main/java/com/example/beside/util/Common.java
+++ b/src/main/java/com/example/beside/util/Common.java
@@ -39,11 +39,10 @@ public class Common {
     }
 
     public static Boolean NicknameValidate(String nickname) throws UserValidateNickName {
-        Pattern pattern = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]{1,8}$");
-        Matcher matcher = pattern.matcher(nickname);
-        if(!matcher.find()) {
-            throw new UserValidateNickName("한글, 영문, 숫자 조합 8자 이내");
+        if(nickname.length()>8) {
+            throw new UserValidateNickName("닉네임은 8자 이내여야 합니다.");
         }
+
         return true;
     }
 }

--- a/src/test/java/com/example/beside/service/UserServiceTest.java
+++ b/src/test/java/com/example/beside/service/UserServiceTest.java
@@ -230,23 +230,4 @@ public class UserServiceTest {
         assertThrows(UserValidateNickName.class, () -> userService.updateNickname(user5));
     }
 
-    @Test
-    @DisplayName("특수 문자가 포함된 닉네임 변경")
-    void testUpdateNickNameIncludeExclamationMark() throws PasswordException, UserValidateNickName {
-        // given
-        userService.saveUser(user6);
-        user6.setName("!@#은지");
-        // when, then
-        assertThrows(UserValidateNickName.class, () -> userService.updateNickname(user6));
-    }
-
-    @Test
-    @DisplayName("소셜타입이 모임일 경우 중복 닉네임")
-    void testUpdateMoimNickNameDuplication() throws PasswordException, UserValidateNickName {
-        // given
-        userService.saveUser(user7);
-
-        // when, then
-        assertThrows(IllegalStateException.class, () -> userService.updateNickname(user7));
-    }
 }


### PR DESCRIPTION
1. 닉네임 중복 검사 로직 제거
2. 닉네임 입력시 특수문자 포함 가능