### PR TITLE
알람 상태값 한개만 변경가능하도록 수정

### DIFF
--- a/src/main/java/com/example/beside/api/user/UserController.java
+++ b/src/main/java/com/example/beside/api/user/UserController.java
@@ -210,13 +210,18 @@ public class UserController {
             @RequestBody @Validated UpdateAlarmStateRequest request) {
 
         User user = (User) token.getAttribute("user");
-
         User updateUser = new User();
+
         updateUser.setId(user.getId());
         updateUser.setPush_alarm(request.push_alarm);
         updateUser.setMarketing_alarm(request.marketing_alarm);
-        User changUser = userService.updateAlarmState(updateUser);
 
+        if (request.push_alarm == null)
+            updateUser.setPush_alarm(user.getPush_alarm());
+        if (request.marketing_alarm == null)
+            updateUser.setMarketing_alarm(user.getMarketing_alarm());
+
+        User changUser = userService.updateAlarmState(updateUser);
         UserDto userDto = new UserDto(changUser);
 
         return UserResponse.success(200, "알람 상태가 변경 되었습니다.", userDto);
@@ -443,10 +448,9 @@ public class UserController {
 
     @Data
     static class UpdateAlarmStateRequest {
-        @NotNull
         @Schema(description = "push_alarm", example = "푸쉬 알림", type = "Boolean")
         private Boolean push_alarm;
-        @NotNull
+
         @Schema(description = "marketing_alarm", example = "마케팅 알림", type = "Boolean")
         private Boolean marketing_alarm;
     }


### PR DESCRIPTION
알람 상태여부 변경 API 관련, 마케팅과, 푸쉬알림 중 각각 변경이 가능하도록 변경합니다.

**[마케팅 여부만]**
![image](https://github.com/ej522/bside/assets/19955904/31a29b49-ada7-47be-9992-591f3b0ad959)

**[푸쉬알림 여부만]**
![image](https://github.com/ej522/bside/assets/19955904/87d9fbd0-fba9-4fb2-9dc9-dd3a4e1c80d9)

**[두개 모두 변경]**
![image](https://github.com/ej522/bside/assets/19955904/53c4a983-76de-4733-8484-c98756130609)
