### PR TITLE
카카오 전체 동의하기 안누른 경우 버그 수정

### DIFF
--- a/src/main/java/com/example/beside/service/SocialLoginService.java
+++ b/src/main/java/com/example/beside/service/SocialLoginService.java
@@ -72,7 +72,9 @@ public class SocialLoginService {
             KakaoLoginInfoDto kakaoLoginInfo = gson.fromJson(response.toString(), KakaoLoginInfoDto.class);
 
             var kakao_id = String.valueOf(kakaoLoginInfo.getId());
-            var nickname = kakaoLoginInfo.getKakao_account().profile.nickname;
+            var nickname = "";
+            if (kakaoLoginInfo.getKakao_account().profile != null)
+                nickname = kakaoLoginInfo.getKakao_account().profile.nickname;
 
             userInfo.setEmail(kakao_id);
             userInfo.setName(nickname);


### PR DESCRIPTION
카카오 소셜로그인으로 회원가입시 "전체 동의하기" 안누른 경우 발생하는 에러 수정합니다.

![image](https://github.com/ej522/bside/assets/19955904/30714c44-4e7f-487a-aa2a-41c50d7672b8)
