### PR TITLE
코드 가독성을 좋게 만들어 봅니다

### DIFF
--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -222,9 +222,9 @@ public class MoimService {
             throw new NoResultListException("과거 모임 목록이 없습니다.");
 
         for (int i = 0; i < moimList.size(); i++) {
-            MyMoimDto moim = moimList.get(i);
-            String fixedDate = moim.getFixed_date();
-            int fixedHour = Integer.parseInt(moim.getFixed_time());
+            MyMoimDto moimDto = moimList.get(i);
+            String fixedDate = moimDto.getFixed_date();
+            int fixedHour = Integer.parseInt(moimDto.getFixed_time());
 
             int year = Integer.parseInt(fixedDate.split("-")[0]);
             int month = Integer.parseInt(fixedDate.split("-")[1]);
@@ -236,10 +236,10 @@ public class MoimService {
                 continue;
             }
 
-            int moimMemberCnt = moimRepository.findMemberCount(moim.getMoim_id());
+            int moimMemberCnt = moimRepository.findMemberCount(moimDto.getMoim_id());
             moimMemberCnt += 1;
 
-            moim.setMemeber_cnt(moimMemberCnt);
+            moimDto.setMemeber_cnt(moimMemberCnt);
         }
 
         return moimList;


### PR DESCRIPTION
과거 모임 목록 조회 API 의 가독성을 향상 시켜 봅니다.
@ej522 어때용?

@y8ns  해당 API 는 현재 날짜 기준, 확정된 날짜의 '년,원,일,시' 까지 비교해서, 과거내용을 보내줍니다.

> 즉 '2023-06-20 18'시 에 확정된 모임이 있고,  '2023-06-20 18:30' 분에 해당 API 를 조회하면,  확정된 모임이 조회됩니다. 
