### PR TITLE
시간투표결과 주최자가 선택한 시간대에 따른 결과 반환

### DIFF
--- a/src/main/java/com/example/beside/repository/MoimRepository.java
+++ b/src/main/java/com/example/beside/repository/MoimRepository.java
@@ -8,12 +8,7 @@ import com.example.beside.domain.MoimDate;
 import com.example.beside.domain.MoimMember;
 import com.example.beside.domain.MoimMemberTime;
 import com.example.beside.domain.User;
-import com.example.beside.dto.InvitedMoimListDto;
-import com.example.beside.dto.MoimOveralDateDto;
-import com.example.beside.dto.MoimOveralScheduleDto;
-import com.example.beside.dto.MyMoimDto;
-import com.example.beside.dto.VoteMoimTimeCntDto;
-import com.example.beside.dto.VotingMoimDto;
+import com.example.beside.dto.*;
 
 public interface MoimRepository {
     // CREATE
@@ -59,6 +54,7 @@ public interface MoimRepository {
     VoteMoimTimeCntDto getTimeVoteCnt(Long moimId, LocalDateTime selectedDate);
 
     List<MyMoimDto> findMyMoimFutureList(Long userId);
+    MoimDateDto findMoimDateByMoimIdAndDate(Long moimId, LocalDateTime selectedDate);
 
     // UPDATE
     long deleteHostHistory(Long userId, Long moimId);

--- a/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
+++ b/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
@@ -627,6 +627,25 @@ public class MoimRepositoryImpl implements MoimRepository {
                 return result;
         }
 
+        @Override
+        public MoimDateDto findMoimDateByMoimIdAndDate(Long moimId, LocalDateTime selectedDate) {
+                queryFactory = new JPAQueryFactory(em);
+
+                QMoimDate qMoimDate = QMoimDate.moimDate;
+
+                MoimDateDto result = queryFactory.select(
+                        Projections.constructor(MoimDateDto.class,
+                                qMoimDate.morning,
+                                qMoimDate.afternoon,
+                                qMoimDate.evening,
+                                qMoimDate.selected_date))
+                        .from(qMoimDate)
+                        .where(qMoimDate.moim.id.eq(moimId).and(qMoimDate.selected_date.eq(selectedDate)))
+                        .fetchOne();
+
+                return result;
+        }
+
         private NumberExpression<Integer> getTimeCnt(Object object) {
                 return Expressions
                                 .numberTemplate(Integer.class, "count(case when {0} then 1 end)", object);

--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -449,19 +449,29 @@ public class MoimService {
             }
         }
 
-        timeInfoList = setVoteTimeInfoList(timeInfoList, am9Info, am9userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, am10Info, am10userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, am11Info, am11userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm12Info, pm12userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm1Info, pm1userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm2Info, pm2userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm3Info, pm3userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm4Info, pm4userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm5Info, pm5userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm6Info, pm6userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm7Info, pm7userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm8Info, pm8userInfoList);
-        timeInfoList = setVoteTimeInfoList(timeInfoList, pm9Info, pm9userInfoList);
+        //주최자가 설정한 모임 날짜별 시간
+        MoimDateDto moimDateInfo = moimRepository.findMoimDateByMoimIdAndDate(moimId, selected_date);
+        if(moimDateInfo.isMorning()) {
+            timeInfoList = setVoteTimeInfoList(timeInfoList, am9Info, am9userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, am10Info, am10userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, am11Info, am11userInfoList);
+        }
+
+        if(moimDateInfo.isAfternoon()) {
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm12Info, pm12userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm1Info, pm1userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm2Info, pm2userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm3Info, pm3userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm4Info, pm4userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm5Info, pm5userInfoList);
+        }
+
+        if(moimDateInfo.isEvening()) {
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm6Info, pm6userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm7Info, pm7userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm8Info, pm8userInfoList);
+            timeInfoList = setVoteTimeInfoList(timeInfoList, pm9Info, pm9userInfoList);
+        }
 
         moimTimeInfo.setTime_info(timeInfoList);
 

--- a/src/test/java/com/example/beside/repository/MoimRepositoryTest.java
+++ b/src/test/java/com/example/beside/repository/MoimRepositoryTest.java
@@ -407,4 +407,26 @@ public class MoimRepositoryTest {
         Assertions.assertThat(result.get(0).getFixed_time()).isLessThanOrEqualTo("12");
     }
 
+    @Test
+    @DisplayName("주최자가 설정한 날짜 목록을 모임아이디와 선택된 날짜로 조회할 수 있는가?")
+    void testFindMoimDateByMoimIdAndDate() throws Exception {
+        // given
+        User findUser = userRepository.saveUser(user);
+
+        newMoim.setUser(findUser);
+        // 모임 생성
+        long moimId = moimRepository.makeMoim(findUser, newMoim, moimdate1);
+        newMoim.setId(moimId);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        //when
+        MoimDateDto result = moimRepository.findMoimDateByMoimIdAndDate(moimId, LocalDate.parse("2023-03-10", formatter).atStartOfDay());
+
+        //then
+        Assertions.assertThat(result.isMorning()).isFalse();
+        Assertions.assertThat(result.isAfternoon()).isFalse();
+        Assertions.assertThat(result.isEvening()).isTrue();
+    }
+
 }


### PR DESCRIPTION
주최자가 선택한 시간대에 따라 투표결과를 반환합니다.
기존에는 주최자 선택과 무관하게 9 ~ 21시 모두 조회되었습니다.
주최자가 선택한 오전(9 ~ 11), 오후(12 ~ 17), 저녁(18 ~ 21)에 맞게 시간 투표 결과를 반환합니다.