### PR TITLE
암호화된 모임 아이디로 조회 시 반환하는 데이터 값 수정

### DIFF
--- a/src/main/java/com/example/beside/api/moim/MoimController.java
+++ b/src/main/java/com/example/beside/api/moim/MoimController.java
@@ -317,14 +317,14 @@ public class MoimController {
     }
     @Operation(tags = { "Moim" }, summary = "딥링크를 통한 모임 조회")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "모임 정보가 조회되었습니다.", content = @Content(schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "200", description = "모임 정보가 조회되었습니다.", content = @Content(schema = @Schema(implementation = DeepLinkMoimResponse.class))),
             @ApiResponse(responseCode = "404", description = "해당 모임이 존재하지 않습니다.")
     })
     @GetMapping(value = "/v1/deeplink-info")
-    public Response getMoimInfoByDeepLink(@RequestParam(name = "encryptInfo") @NotNull String encryptInfo) throws Exception {
-        MoimDto moimInfo = moimService.getMoimInfoByMoimId(encryptInfo);
+    public DeepLinkMoimResponse getMoimInfoByDeepLink(@RequestParam(name = "encryptInfo") @NotNull String encryptInfo) throws Exception {
+        MoimDto moimInfo = moimService.getMoimNameAndDeadLine(encryptInfo);
 
-        return Response.success(200, "모임 정보가 조회되었습니다.", moimInfo);
+        return DeepLinkMoimResponse.success(200, "모임 정보가 조회되었습니다.", moimInfo);
 
     }
 

--- a/src/main/java/com/example/beside/common/response/DeepLinkMoimResponse.java
+++ b/src/main/java/com/example/beside/common/response/DeepLinkMoimResponse.java
@@ -1,0 +1,40 @@
+package com.example.beside.common.response;
+
+import com.example.beside.dto.MoimDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(name = "MoinInfo", description = "모임 조회")
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DeepLinkMoimResponse {
+    @Schema(description = "상태 코드", nullable = false)
+    private int httpStatusCode;
+
+    @Schema(description = "메시지", nullable = false)
+    private String msg;
+
+    @Schema(description = "데이터", nullable = true)
+    private MoimDto data;
+
+    @Builder
+    public DeepLinkMoimResponse(int httpStatusCode, String msg, MoimDto data) {
+        this.httpStatusCode = httpStatusCode;
+        this.msg = msg;
+        this.data = data;
+    }
+
+    public static DeepLinkMoimResponse success(int httpStatusCode, String msg, MoimDto data) {
+        return new DeepLinkMoimResponse(httpStatusCode, msg, data);
+    }
+
+    public static DeepLinkMoimResponse fail(int httpStatusCode, String errorMessage) {
+        return new DeepLinkMoimResponse(httpStatusCode, errorMessage, null);
+    }
+
+    public static DeepLinkMoimResponse fail(int httpStatusCode, String errorMessage, MoimDto data) {
+        return new DeepLinkMoimResponse(httpStatusCode, errorMessage, data);
+    }
+}

--- a/src/main/java/com/example/beside/common/response/MoimListResponse.java
+++ b/src/main/java/com/example/beside/common/response/MoimListResponse.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
-@Schema(name = "MyMoimList", description = "확정 모임 조회")
+@Schema(name = "MoimList", description = "모임 여러개 조회")
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MoimListResponse {

--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -551,7 +551,7 @@ public class MoimService {
         LocalDateTime deadline = Common.calculateDeadLineTime(moimInfo.getCreated_time(), moimInfo.getDead_line_hour());
 
         MoimDto summInfo = new MoimDto();
-        summInfo.setMoim_name(moimInfo.getMoim_name());
+        summInfo.setHost_name(moimInfo.getHost_name());
         summInfo.setDead_line_time(deadline);
 
         return summInfo;

--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -539,7 +539,7 @@ public class MoimService {
     }
 
     //모임정보
-    public MoimDto getMoimInfoByMoimId(String encryptInfo) throws Exception {
+    public MoimDto getMoimNameAndDeadLine(String encryptInfo) throws Exception {
         Long moimId = Long.parseLong(encrypt.decrypt(encryptInfo));
 
         MoimDto moimInfo = moimRepository.findMoimByMoimId(moimId);
@@ -548,9 +548,13 @@ public class MoimService {
             throw new NoResultListException("해당 모임이 존재하지 않습니다.");
         }
 
-        moimInfo.setDead_line_time(Common.calculateDeadLineTime(moimInfo.getCreated_time(), moimInfo.getDead_line_hour()));
+        LocalDateTime deadline = Common.calculateDeadLineTime(moimInfo.getCreated_time(), moimInfo.getDead_line_hour());
 
-        return moimInfo;
+        MoimDto summInfo = new MoimDto();
+        summInfo.setMoim_name(moimInfo.getMoim_name());
+        summInfo.setDead_line_time(deadline);
+
+        return summInfo;
     }
 
     private List<UserDto> setTimeUserInfo(MoimOveralScheduleDto voteUserInfo, List<UserDto> voteUserInfoList) {


### PR DESCRIPTION
암호화된 몸임 아이디로 조회할 경우 주최자 닉네임, 데드라인 외의 값은 null
![image](https://github.com/ej522/bside/assets/75981333/d8f7e41c-61bf-4ede-a209-d92b92a7ba65)
