### PR TITLE
Feature/invite moim logic change

### DIFF
--- a/src/main/java/com/example/beside/api/moim/MoimController.java
+++ b/src/main/java/com/example/beside/api/moim/MoimController.java
@@ -350,7 +350,6 @@ public class MoimController {
         private String moimName;
 
         @NotNull
-        @Max(48)
         @Schema(description = "데드라인 시간", example = "5", type = "int")
         private int deadLineHour;
 

--- a/src/main/java/com/example/beside/domain/MoimMember.java
+++ b/src/main/java/com/example/beside/domain/MoimMember.java
@@ -36,6 +36,7 @@ public class MoimMember {
     @ColumnDefault("true")
     private Boolean history_view_yn;
 
+    @ColumnDefault("false")
     private Boolean is_accept;
 
 }

--- a/src/main/java/com/example/beside/dto/InvitedMoimListDto.java
+++ b/src/main/java/com/example/beside/dto/InvitedMoimListDto.java
@@ -33,17 +33,13 @@ public class InvitedMoimListDto {
     @Schema(description = "마감기한", example = "YYYY-MM-DD HH24:mi:ss")
     private LocalDateTime deadLineTime;
 
-    @Schema(description = "모임 참여 여부", example = "true")
-    private Boolean is_accept_this_moim;
-
     public InvitedMoimListDto(Long moim_id, String moim_name, String moim_leader, LocalDateTime createdTime,
-            int dead_line_hour, Boolean is_accept_this_moim) {
+            int dead_line_hour) {
         this.moim_id = moim_id;
         this.moim_name = moim_name;
         this.moim_leader = moim_leader;
         this.createdTime = createdTime;
         this.dead_line_hour = dead_line_hour;
         this.deadLineTime = createdTime.plusHours(dead_line_hour);
-        this.is_accept_this_moim = is_accept_this_moim;
     }
 }

--- a/src/main/java/com/example/beside/dto/VotingMoimDto.java
+++ b/src/main/java/com/example/beside/dto/VotingMoimDto.java
@@ -39,7 +39,6 @@ public class VotingMoimDto {
     @Schema(description = "데드 라인 시간", example = "2023-12-20")
     private int dead_line_hour;
 
-    @NotEmpty
     @Schema(description = "모임 확정 시간", example = "2023-12-20")
     private LocalDateTime dead_line_time;
 
@@ -50,7 +49,7 @@ public class VotingMoimDto {
         this.moim_name = newDto.moim_name;
         this.created_time = newDto.created_time;
         this.dead_line_hour = newDto.dead_line_hour;
-        this.dead_line_time = calculateDeadLineTime(created_time, dead_line_hour);
+        this.dead_line_time = calculateDeadLineTime(newDto.created_time, newDto.dead_line_hour);
     }
 
     @PostLoad

--- a/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
+++ b/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
@@ -192,37 +192,37 @@ public class MoimRepositoryImpl implements MoimRepository {
                 queryFactory = new JPAQueryFactory(em);
 
                 QMoim qMoim = QMoim.moim;
-                QUser qUser = QUser.user;
                 QMoimMember qMoimMember = QMoimMember.moimMember;
 
-                // 내가 참여한 모임
+                // 모임원
                 JPAQuery<VotingMoimDto> query1 = queryFactory
-                                .select(Projections.fields(VotingMoimDto.class, qUser.id.as("user_id"),
-                                                qUser.name.as("user_name"),
+                                .select(Projections.fields(VotingMoimDto.class,
+                                                qMoim.user.id.as("user_id"),
+                                                qMoim.user.name.as("user_name"),
                                                 qMoim.id.as("moim_id"),
                                                 qMoim.moim_name.as("moim_name"),
                                                 qMoim.created_time.as("created_time"),
                                                 qMoim.dead_line_hour.as("dead_line_hour")))
-                                .from(qMoim)
-                                .innerJoin(qUser).on(qUser.id.eq(qMoim.user.id))
-                                .where(qMoim.id.in(
-                                                JPAExpressions.select(qMoimMember.moim.id)
-                                                                .from(qMoimMember)
-                                                                .where(qMoimMember.user_id.eq(user_id)
-                                                                                .and(qMoimMember.is_accept.eq(true))))
-                                                .and(qMoim.fixed_date.isNull()));
+                                .from(qMoim).innerJoin(qMoimMember)
+                                .on(qMoim.id.eq(qMoimMember.moim.id))
+                                .where(qMoim.user.id.ne(user_id)
+                                                .and(qMoim.fixed_date.isNull())
+                                                .and(qMoimMember.user_id.eq(user_id))
+                                                .and(qMoimMember.is_accept.isTrue()));
 
-                // // 내가 모임장인 모임
+                // 모임장
                 JPAQuery<VotingMoimDto> query2 = queryFactory
-                                .select(Projections.fields(VotingMoimDto.class, qUser.id.as("user_id"),
-                                                qUser.name.as("user_name"),
+                                .select(Projections.fields(VotingMoimDto.class,
+                                                qMoim.user.id.as("user_id"),
+                                                qMoim.user.name.as("user_name"),
                                                 qMoim.id.as("moim_id"),
                                                 qMoim.moim_name.as("moim_name"),
                                                 qMoim.created_time.as("created_time"),
                                                 qMoim.dead_line_hour.as("dead_line_hour")))
-                                .from(qMoim)
-                                .innerJoin(qUser).on(qUser.id.eq(qMoim.user.id))
-                                .where(qMoim.user.id.eq(user_id).and(qMoim.fixed_date.isNull()));
+                                .from(qMoim).innerJoin(qMoimMember)
+                                .on(qMoim.id.eq(qMoimMember.moim.id))
+                                .where(qMoim.user.id.eq(user_id)
+                                                .and(qMoim.fixed_date.isNull()));
 
                 // UINON ALL
                 List<VotingMoimDto> result = query1.fetch();
@@ -241,25 +241,21 @@ public class MoimRepositoryImpl implements MoimRepository {
         public List<InvitedMoimListDto> getInvitedMoimList(Long user_id) {
                 queryFactory = new JPAQueryFactory(em);
 
-                QUser qUser = QUser.user;
                 QMoim qMoim = QMoim.moim;
                 QMoimMember qMoimMember = QMoimMember.moimMember;
-                QMoimMemberTime qMoimMemberTime = QMoimMemberTime.moimMemberTime;
 
                 List<InvitedMoimListDto> result = queryFactory.select(Projections.constructor(InvitedMoimListDto.class,
                                 qMoim.id.as("moim_id"),
                                 qMoim.moim_name.as("moim_name"),
-                                qUser.name.as("moim_leader"),
+                                qMoim.user.name.as("moim_leader"),
                                 qMoim.created_time.as("createdTime"),
-                                qMoim.dead_line_hour.as("dead_line_hour"),
-                                qMoimMember.is_accept.as("is_accept_this_moim")))
-                                .from(qUser).innerJoin(qMoim)
-                                .on(qUser.id.eq(qMoim.user.id)).leftJoin(qMoimMember)
-                                .on(qMoim.id.eq(qMoimMember.moim.id)).leftJoin(qMoimMemberTime)
-                                .on(qMoimMember.id.eq(qMoimMemberTime.moim_member.id))
-                                .where(qMoimMember.user_id.eq(user_id)
+                                qMoim.dead_line_hour.as("dead_line_hour")))
+                                .from(qMoim).leftJoin(qMoimMember)
+                                .on(qMoim.id.eq(qMoimMember.moim.id))
+                                .where(qMoim.user.id.ne(user_id)
                                                 .and(qMoim.fixed_date.isNull()
-                                                                .and(qMoimMemberTime.selected_date.isNull())))
+                                                                .and(qMoimMember.user_id.eq(user_id))
+                                                                .and(qMoimMember.is_accept.isFalse())))
                                 .fetch();
 
                 return result;
@@ -382,13 +378,13 @@ public class MoimRepositoryImpl implements MoimRepository {
                 QMoimMember qMoimMember = QMoimMember.moimMember;
                 QMoimMemberTime qMoimMemberTime = QMoimMemberTime.moimMemberTime;
 
-                //모임 투표한 날짜
+                // 모임 투표한 날짜
                 queryFactory.delete(qMoimMemberTime).where(qMoimMemberTime.moim_id.eq(moimId)).execute();
-                //모임 멤버
+                // 모임 멤버
                 queryFactory.delete(qMoimMember).where(qMoimMember.moim.id.eq(moimId)).execute();
-                //주최자가 선택한 모임 날짜
+                // 주최자가 선택한 모임 날짜
                 queryFactory.delete(qMoimDate).where(qMoimDate.moim.id.eq(moimId)).execute();
-                //모임
+                // 모임
                 queryFactory.delete(qMoim).where(qMoim.id.eq(moimId)).execute();
 
                 em.flush();

--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -645,36 +645,6 @@ public class MoimService {
         return summInfo;
     }
 
-    private List<UserDto> setTimeUserInfo(MoimOveralScheduleDto voteUserInfo, List<UserDto> voteUserInfoList) {
-        UserDto userDto = new UserDto();
-        userDto.setId(voteUserInfo.getUser_id());
-        userDto.setName(voteUserInfo.getMember_name());
-        userDto.setProfile_image(voteUserInfo.getProfile_image());
-
-        voteUserInfoList.add(userDto);
-
-        return voteUserInfoList;
-    }
-
-    // private VoteMoimTimeDetailDto setTimeInfo(int time, int cnt) {
-    // VoteMoimTimeDetailDto timeInfo = new VoteMoimTimeDetailDto();
-    // timeInfo.setTime(time);
-    // timeInfo.setVote_cnt(cnt);
-    //
-    // return timeInfo;
-    // }
-    //
-    // private List<VoteMoimTimeDetailDto>
-    // setVoteTimeInfoList(List<VoteMoimTimeDetailDto> timeInfoList,
-    // VoteMoimTimeDetailDto timeInfo, List<UserDto> useInfoList) {
-    // timeInfo.setUser_info(useInfoList);
-    //
-    // timeInfoList.add(timeInfo);
-    //
-    // return timeInfoList;
-    //
-    // }
-
     private List<VoteMoimTimeDto.TimeVoteInfo> setVoteTimeInfo(List<VoteMoimTimeDto.TimeVoteInfo> timeList,
             VoteMoimTimeDto.TimeVoteInfo timeVoteInfo,
             Integer time, Integer vote_cnt, List<VoteMoimTimeDto.TimeUserInfo> userInfoList) {

--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -310,7 +310,7 @@ public class MoimService {
         // 모임 날짜 정보
         List<MoimOveralDateDto> dateInfoList = moimRepository.getMoimOveralInfo(moimId, null);
 
-        if(dateInfoList.size()==0)
+        if (dateInfoList.size() == 0)
             throw new NoResultListException("해당 모임이 존재하지 않습니다.");
 
         // 투표 인원 정보
@@ -318,33 +318,33 @@ public class MoimService {
 
         VoteMoimDateDto voteMoimDateInfo = new VoteMoimDateDto();
 
-        //총 투표수
+        // 총 투표수
         int total = 0;
 
         voteMoimDateInfo.setMoim_id(dateInfoList.get(0).getId());
 
         List<VoteMoimDateDto.DateVoteInfo> voteInfoList = new ArrayList<>();
 
-        for(int i=0; i<dateInfoList.size(); i++) {
+        for (int i = 0; i < dateInfoList.size(); i++) {
             VoteMoimDateDto.DateVoteInfo voteInfo = new VoteMoimDateDto.DateVoteInfo();
 
             LocalDateTime selected_date = dateInfoList.get(i).getSelected_date();
             voteInfo.setSelected_date(selected_date);
 
-            //각 날짜 투표수
+            // 각 날짜 투표수
             int vote_cnt = 0;
 
             List<VoteMoimDateDto.DateUserInfo> userInfoList = new ArrayList<>();
 
-            for(MoimOveralScheduleDto voteUserInfo : voteUserInfoList) {
-                if(voteUserInfo.getSelected_date()==null) {//투표한 사람이 없는 경우
+            for (MoimOveralScheduleDto voteUserInfo : voteUserInfoList) {
+                if (voteUserInfo.getSelected_date() == null) {// 투표한 사람이 없는 경우
                     break;
                 }
 
-                if(selected_date.isEqual(voteUserInfo.getSelected_date())) {
+                if (selected_date.isEqual(voteUserInfo.getSelected_date())) {
                     VoteMoimDateDto.DateUserInfo userInfo = new VoteMoimDateDto.DateUserInfo();
 
-                    //투표자 정보
+                    // 투표자 정보
                     userInfo.setUser_id(voteUserInfo.getUser_id());
                     userInfo.setNickname(voteUserInfo.getMember_name());
                     userInfo.setProfile(voteUserInfo.getProfile_image());
@@ -372,7 +372,7 @@ public class MoimService {
     public VoteMoimTimeDto getVoteTimeInfo(Long moimId, LocalDateTime selected_date) throws Exception {
         // 모임 날짜 정보
         List<MoimOveralDateDto> dateInfoList = moimRepository.getMoimOveralInfo(moimId, selected_date);
-        if(dateInfoList.size()==0)
+        if (dateInfoList.size() == 0)
             throw new NoResultListException("잘못된 날짜를 선택하셨습니다.");
 
         // 투표 인원 정보
@@ -385,7 +385,7 @@ public class MoimService {
         moimTimeInfo.setMoim_id(voteUserInfoList.get(0).getMoim_id());
         moimTimeInfo.setSelected_date(selected_date);
 
-        //시간
+        // 시간
         VoteMoimTimeDto.TimeVoteInfo am9Info = new VoteMoimTimeDto.TimeVoteInfo();
         VoteMoimTimeDto.TimeVoteInfo am10Info = new VoteMoimTimeDto.TimeVoteInfo();
         VoteMoimTimeDto.TimeVoteInfo am11Info = new VoteMoimTimeDto.TimeVoteInfo();
@@ -428,100 +428,100 @@ public class MoimService {
         List<VoteMoimTimeDto.TimeUserInfo> pm20userInfoList = new ArrayList<>();
         List<VoteMoimTimeDto.TimeUserInfo> pm21userInfoList = new ArrayList<>();
 
-        for(MoimOveralScheduleDto voteUserInfo : voteUserInfoList) {
-            if(voteUserInfo.getSelected_date()==null) {//투표한 사람이 없는 경우
+        for (MoimOveralScheduleDto voteUserInfo : voteUserInfoList) {
+            if (voteUserInfo.getSelected_date() == null) {// 투표한 사람이 없는 경우
                 break;
             }
 
             VoteMoimTimeDto.TimeUserInfo userInfo = new VoteMoimTimeDto.TimeUserInfo();
 
-            //해당 날짜의 시간에 투표한 인원
-            if(selected_date.isEqual(voteUserInfo.getSelected_date())) {
-                if(voteUserInfo.getAm_nine()) {
+            // 해당 날짜의 시간에 투표한 인원
+            if (selected_date.isEqual(voteUserInfo.getSelected_date())) {
+                if (voteUserInfo.getAm_nine()) {
                     am9userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, am9userInfoList);
 
                     am9Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getAm_ten()) {
+                if (voteUserInfo.getAm_ten()) {
                     am10userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, am10userInfoList);
 
                     am10Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getAm_eleven()) {
+                if (voteUserInfo.getAm_eleven()) {
                     am11userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, am11userInfoList);
 
                     am11Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getNoon()) {
+                if (voteUserInfo.getNoon()) {
                     pm12userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm12userInfoList);
 
                     pm12Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_one()) {
+                if (voteUserInfo.getPm_one()) {
                     pm13userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm13userInfoList);
 
                     pm13Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_two()) {
+                if (voteUserInfo.getPm_two()) {
                     pm14userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm14userInfoList);
 
                     pm14Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_three()) {
+                if (voteUserInfo.getPm_three()) {
                     pm15userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm15userInfoList);
 
                     pm15Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_four()) {
+                if (voteUserInfo.getPm_four()) {
                     pm16userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm16userInfoList);
 
                     pm16Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_five()) {
+                if (voteUserInfo.getPm_five()) {
                     pm17userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm17userInfoList);
 
                     pm17Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_six()) {
+                if (voteUserInfo.getPm_six()) {
                     pm18userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm18userInfoList);
 
                     pm18Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_seven()) {
+                if (voteUserInfo.getPm_seven()) {
                     pm19userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm19userInfoList);
 
                     pm19Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_eight()) {
+                if (voteUserInfo.getPm_eight()) {
                     pm20userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm20userInfoList);
 
                     pm20Cnt++;
                     total++;
                 }
 
-                if(voteUserInfo.getPm_nine()) {
+                if (voteUserInfo.getPm_nine()) {
                     pm21userInfoList = setVoteTimeUserInfoList(userInfo, voteUserInfo, pm21userInfoList);
 
                     pm21Cnt++;
@@ -531,8 +531,8 @@ public class MoimService {
 
         }
 
-        //오전
-        if(dateInfoList.get(0).getMorning()) {
+        // 오전
+        if (dateInfoList.get(0).getMorning()) {
             List<VoteMoimTimeDto.TimeVoteInfo> moringList = new ArrayList<>();
             moringList = setVoteTimeInfo(moringList, am9Info, 9, am9Cnt, am9userInfoList);
             moringList = setVoteTimeInfo(moringList, am10Info, 10, am10Cnt, am10userInfoList);
@@ -540,27 +540,26 @@ public class MoimService {
             moimTimeInfo.setMorning(moringList);
         }
 
-
-        //오후
-        if(dateInfoList.get(0).getAfternoon()) {
+        // 오후
+        if (dateInfoList.get(0).getAfternoon()) {
             List<VoteMoimTimeDto.TimeVoteInfo> afternoonList = new ArrayList<>();
-            afternoonList = setVoteTimeInfo(afternoonList, pm12Info,12, pm12Cnt, pm12userInfoList);
-            afternoonList = setVoteTimeInfo(afternoonList, pm13Info,13, pm13Cnt, pm13userInfoList);
-            afternoonList = setVoteTimeInfo(afternoonList, pm14Info,14, pm14Cnt, pm14userInfoList);
-            afternoonList = setVoteTimeInfo(afternoonList, pm15Info,15, pm15Cnt, pm15userInfoList);
-            afternoonList = setVoteTimeInfo(afternoonList, pm16Info,16, pm16Cnt, pm16userInfoList);
-            afternoonList = setVoteTimeInfo(afternoonList, pm17Info,17, pm17Cnt, pm17userInfoList);
+            afternoonList = setVoteTimeInfo(afternoonList, pm12Info, 12, pm12Cnt, pm12userInfoList);
+            afternoonList = setVoteTimeInfo(afternoonList, pm13Info, 13, pm13Cnt, pm13userInfoList);
+            afternoonList = setVoteTimeInfo(afternoonList, pm14Info, 14, pm14Cnt, pm14userInfoList);
+            afternoonList = setVoteTimeInfo(afternoonList, pm15Info, 15, pm15Cnt, pm15userInfoList);
+            afternoonList = setVoteTimeInfo(afternoonList, pm16Info, 16, pm16Cnt, pm16userInfoList);
+            afternoonList = setVoteTimeInfo(afternoonList, pm17Info, 17, pm17Cnt, pm17userInfoList);
 
             moimTimeInfo.setAfternoon(afternoonList);
         }
 
-        //저녁
-        if(dateInfoList.get(0).getEvening()) {
+        // 저녁
+        if (dateInfoList.get(0).getEvening()) {
             List<VoteMoimTimeDto.TimeVoteInfo> eveningList = new ArrayList<>();
-            eveningList = setVoteTimeInfo(eveningList, pm18Info,18, pm18Cnt, pm18userInfoList);
-            eveningList = setVoteTimeInfo(eveningList, pm19Info,19, pm19Cnt, pm19userInfoList);
-            eveningList = setVoteTimeInfo(eveningList, pm20Info,20, pm20Cnt, pm20userInfoList);
-            eveningList = setVoteTimeInfo(eveningList, pm21Info,21, pm21Cnt, pm21userInfoList);
+            eveningList = setVoteTimeInfo(eveningList, pm18Info, 18, pm18Cnt, pm18userInfoList);
+            eveningList = setVoteTimeInfo(eveningList, pm19Info, 19, pm19Cnt, pm19userInfoList);
+            eveningList = setVoteTimeInfo(eveningList, pm20Info, 20, pm20Cnt, pm20userInfoList);
+            eveningList = setVoteTimeInfo(eveningList, pm21Info, 21, pm21Cnt, pm21userInfoList);
 
             moimTimeInfo.setEvening(eveningList);
         }
@@ -657,26 +656,28 @@ public class MoimService {
         return voteUserInfoList;
     }
 
-//    private VoteMoimTimeDetailDto setTimeInfo(int time, int cnt) {
-//        VoteMoimTimeDetailDto timeInfo = new VoteMoimTimeDetailDto();
-//        timeInfo.setTime(time);
-//        timeInfo.setVote_cnt(cnt);
-//
-//        return timeInfo;
-//    }
-//
-//    private List<VoteMoimTimeDetailDto> setVoteTimeInfoList(List<VoteMoimTimeDetailDto> timeInfoList,
-//            VoteMoimTimeDetailDto timeInfo, List<UserDto> useInfoList) {
-//        timeInfo.setUser_info(useInfoList);
-//
-//        timeInfoList.add(timeInfo);
-//
-//        return timeInfoList;
-//
-//    }
+    // private VoteMoimTimeDetailDto setTimeInfo(int time, int cnt) {
+    // VoteMoimTimeDetailDto timeInfo = new VoteMoimTimeDetailDto();
+    // timeInfo.setTime(time);
+    // timeInfo.setVote_cnt(cnt);
+    //
+    // return timeInfo;
+    // }
+    //
+    // private List<VoteMoimTimeDetailDto>
+    // setVoteTimeInfoList(List<VoteMoimTimeDetailDto> timeInfoList,
+    // VoteMoimTimeDetailDto timeInfo, List<UserDto> useInfoList) {
+    // timeInfo.setUser_info(useInfoList);
+    //
+    // timeInfoList.add(timeInfo);
+    //
+    // return timeInfoList;
+    //
+    // }
 
-    private List<VoteMoimTimeDto.TimeVoteInfo> setVoteTimeInfo(List<VoteMoimTimeDto.TimeVoteInfo> timeList, VoteMoimTimeDto.TimeVoteInfo timeVoteInfo,
-                                                         Integer time, Integer vote_cnt, List<VoteMoimTimeDto.TimeUserInfo> userInfoList) {
+    private List<VoteMoimTimeDto.TimeVoteInfo> setVoteTimeInfo(List<VoteMoimTimeDto.TimeVoteInfo> timeList,
+            VoteMoimTimeDto.TimeVoteInfo timeVoteInfo,
+            Integer time, Integer vote_cnt, List<VoteMoimTimeDto.TimeUserInfo> userInfoList) {
         timeVoteInfo.setSelected_time(time);
         timeVoteInfo.setVote_cnt(vote_cnt);
         timeVoteInfo.setUserInfo(userInfoList);
@@ -686,8 +687,9 @@ public class MoimService {
         return timeList;
     }
 
-    private List<VoteMoimTimeDto.TimeUserInfo> setVoteTimeUserInfoList(VoteMoimTimeDto.TimeUserInfo userInfo, MoimOveralScheduleDto voteUserInfo,
-                                                                       List<VoteMoimTimeDto.TimeUserInfo> userInfoList) {
+    private List<VoteMoimTimeDto.TimeUserInfo> setVoteTimeUserInfoList(VoteMoimTimeDto.TimeUserInfo userInfo,
+            MoimOveralScheduleDto voteUserInfo,
+            List<VoteMoimTimeDto.TimeUserInfo> userInfoList) {
 
         userInfo.setUser_id(voteUserInfo.getUser_id());
         userInfo.setNickname(voteUserInfo.getMember_name());

--- a/src/test/java/com/example/beside/service/MoimServiceTest.java
+++ b/src/test/java/com/example/beside/service/MoimServiceTest.java
@@ -498,17 +498,17 @@ public class MoimServiceTest {
         newMoim.setDead_line_hour(5);
 
         Moim newMoim2 = new Moim();
-        newMoim.setUser(saveUser1);
-        newMoim.setMoim_name("테스트 모임2");
-        newMoim.setDead_line_hour(5);
+        newMoim2.setUser(saveUser1);
+        newMoim2.setMoim_name("테스트 모임2");
+        newMoim2.setDead_line_hour(5);
 
         // [모임 생성]
         String encryptedId = moimService.makeMoim(saveUser1, newMoim, normalMoimDates);
         // [모임 참여 -> 친구 생성]
         moimService.participateDeepLink(saveUser2, encryptedId);
-
         // [모임 생성]
         String encryptedId2 = moimService.makeMoim(saveUser1, newMoim2, normalMoimDates);
+
         List<String> friendIdList = new ArrayList<>();
         friendIdList.add(String.valueOf(saveUser2.getId()));
         // [모임 초대]
@@ -581,8 +581,10 @@ public class MoimServiceTest {
         // given
         assertTrue(result.getTotal().equals(1));
         assertTrue(result.getTotal().equals(1));
-        assertTrue(result.getVoteList().get(0).getSelected_date().isEqual(LocalDate.parse("2023-03-10", formatter).atStartOfDay()));
-        assertTrue(result.getVoteList().get(1).getSelected_date().isEqual(LocalDate.parse("2023-03-13", formatter).atStartOfDay()));
+        assertTrue(result.getVoteList().get(0).getSelected_date()
+                .isEqual(LocalDate.parse("2023-03-10", formatter).atStartOfDay()));
+        assertTrue(result.getVoteList().get(1).getSelected_date()
+                .isEqual(LocalDate.parse("2023-03-13", formatter).atStartOfDay()));
         assertTrue(result.getVoteList().get(0).getVote_cnt().equals(0));
         assertTrue(result.getVoteList().get(1).getVote_cnt().equals(1));
     }
@@ -617,12 +619,12 @@ public class MoimServiceTest {
                 LocalDate.parse("2023-03-13", formatter).atStartOfDay());
 
         // then
-        assertTrue(result.getTotal()==2);
-        assertTrue(result.getMorning()!=null);
-        assertTrue(result.getAfternoon()!=null);
-        assertTrue(result.getEvening()==null);
-        assertTrue(result.getMorning().get(0).getVote_cnt()==0);  //am9
-        assertTrue(result.getAfternoon().get(1).getVote_cnt()>0); //pm1
+        assertTrue(result.getTotal() == 2);
+        assertTrue(result.getMorning() != null);
+        assertTrue(result.getAfternoon() != null);
+        assertTrue(result.getEvening() == null);
+        assertTrue(result.getMorning().get(0).getVote_cnt() == 0); // am9
+        assertTrue(result.getAfternoon().get(1).getVote_cnt() > 0); // pm1
 
     }
 


### PR DESCRIPTION
**[변경된 투표로직 ]**
- A 모임을 초대한 모임장 B 의 경우
모임장 B의 "수락 전 초대된 모임 리스트"에는 A 모임이 뜨면 안되고, 바로 "투표중인 모임 리스트"에서 떠야합니다.
(주최한 모임장은 수락여부가 필요하지 않음)\


- A 모임을 수락하지 않은 C 모임원의 경우
A 모임은 C 모임원의 "초대된 모임 리스트"에서 떠야하고, "투표중인 모임 리스트"에서는 안떠야 합니다 (아직 수락 전이기 때문)
비슷하게,


- A 모임을 이미 수락한 C 모임원의 경우
A 모임은 C 모임원의 "투표중인 모임 리스트"에서 떠야하고, "초대된 모임 리스트"에서는 안떠야 합니다 (이미 수락한 후기 때문)

<br/>

- Clean Code 책의 가이드에 따르면 사용하지 않는 코드는 주석처리하지 않고 지웁니다 
  -(git history 로 형상관리)

- 초대 모임 48 시간 제한을 제거합니다 (더미 데이터를 위해서),  생각해보면 백엔드에서 강제해야할 이유는 없는것 같아서 
해당 로직은 프론트에서 적용하면 좋을 것 같아요!  @y8ns  @ej522 
