### PR TITLE
투표중인 모임 목록 쿼리 수정

### DIFF
--- a/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
+++ b/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
@@ -206,8 +206,7 @@ public class MoimRepositoryImpl implements MoimRepository {
                                                 qMoim.moim_name.as("moim_name"),
                                                 qMoim.created_time.as("created_time"),
                                                 qMoim.dead_line_hour.as("dead_line_hour")))
-                                .from(qMoim).innerJoin(qMoimMember)
-                                .on(qMoim.id.eq(qMoimMember.moim.id))
+                                .from(qMoim)
                                 .where(qMoim.user.id.eq(user_id)
                                                 .and(qMoim.fixed_date.isNull()));
 


### PR DESCRIPTION
투표중인 모임 목록 쿼리 수정
기존: 모임장일 경우 모임원의 수만큼 나타남
원인: 모임장일 경우 조회 쿼리에서 moim_member와 조인을 해주면서 발생
해결: 본인이 모임장일 경우 굳이 moim_member와 조인해줄 필요가 없기때문에 조인 제거