### PR TITLE
Bugfix/scheduled moim list fix

### DIFF
--- a/src/main/java/com/example/beside/common/config/LogAspect.java
+++ b/src/main/java/com/example/beside/common/config/LogAspect.java
@@ -2,6 +2,7 @@ package com.example.beside.common.config;
 
 
 import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -55,9 +56,9 @@ public class LogAspect {
         ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
         HttpServletRequest request = attributes.getRequest();
         
-        logger.info("======== ERROR ========");
-        logger.info("API 요청: " + request.getRequestURI());
-        logger.info("메서드 인자: {}", inputParms);
+        logger.error("=======================");
+        logger.error("API 요청: " + request.getRequestURI());
+        logger.error("메서드 인자: {}", inputParms);
         logger.error("예외 타입: " + ex.getClass().getSimpleName());
         logger.error("예외 발생: " + ex.getMessage());
         logger_info_user_id(logger, request);

--- a/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
+++ b/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
@@ -574,10 +574,7 @@ public class MoimRepositoryImpl implements MoimRepository {
                 QMoimMember qMoimMember = QMoimMember.moimMember;
                 QUser qUser = QUser.user;
 
-                LocalDateTime today = LocalDateTime.now();
-
-                String formattedDate = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-
+                LocalDateTime currentTime = LocalDateTime.now();
                 List<MoimDto> result = queryFactory.select(
                                 Projections.fields(MoimDto.class,
                                                 qMoim.id.as("moim_id"),
@@ -590,12 +587,10 @@ public class MoimRepositoryImpl implements MoimRepository {
                                 .leftJoin(qMoimMember).on(qMoim.id.eq(qMoimMember.moim.id))
                                 .leftJoin(qUser).on(qUser.id.eq(qMoim.user.id))
                                 .where(((qMoim.user.id.eq(userId).and(qMoim.history_view_yn.eq(true)))
-                                                .or((qMoimMember.user_id.eq(userId)
-                                                                .and(qMoimMember.history_view_yn.eq(true)))))
-                                                .and(qMoim.fixed_date.goe(formattedDate))
-                                                .and(qMoim.fixed_date.isNotNull())
-                                                .and(qMoim.fixed_time.isNotNull())
-                                                .and(qMoimMember.is_accept.eq(true)))
+                                        .or((qMoimMember.user_id.eq(userId).and(qMoimMember.history_view_yn.eq(true)))))
+                                .and(qMoimMember.is_accept.eq(true))
+                                .and(qMoim.fixed_date.isNotNull())
+                                .and(qMoim.fixed_date.concat(" ").concat(qMoim.fixed_time).gt(currentTime.toString())))
                                 .orderBy(qMoim.fixed_date.desc(), qMoim.fixed_time.desc())
                                 .fetch();
 

--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -110,7 +110,7 @@ public class MoimService {
         if (moim.getCreated_time().plusHours(moim.getDead_line_hour()).isBefore(LocalDateTime.now()))
             throw new MoimParticipateException("데드라인 시간이 지난 모임입니다.");
 
-        if (moimRepository.getMoimMembers(moimId).size() > 10)
+        if (moimRepository.getMoimMembers(moimId).size() >= 10)
             throw new MoimParticipateException("모임은 최대 10명 까지 가능합니다.");
 
         if (moimRepository.alreadyJoinedMoim(moimId, user.getId()))

--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -110,7 +110,7 @@ public class MoimService {
         if (moim.getCreated_time().plusHours(moim.getDead_line_hour()).isBefore(LocalDateTime.now()))
             throw new MoimParticipateException("데드라인 시간이 지난 모임입니다.");
 
-        if (moimRepository.getMoimMembers(moimId).size() >= 10)
+        if (moimRepository.getMoimMembers(moimId).size() > 10)
             throw new MoimParticipateException("모임은 최대 10명 까지 가능합니다.");
 
         if (moimRepository.alreadyJoinedMoim(moimId, user.getId()))
@@ -599,17 +599,13 @@ public class MoimService {
     public List<MoimDto> getMoimFutureList(Long user_id) throws NoResultListException {
         List<MoimDto> moimList = moimRepository.findMyMoimFutureList(user_id);
 
-        if (moimList.isEmpty()) {
+        if (moimList.isEmpty()) 
             throw new NoResultListException("예정 모임 목록이 없습니다.");
-        }
 
         for (MoimDto moim : moimList) {
             int cnt = moimRepository.findMemberCount(moim.getMoim_id());
-
-            // 주최자도 더해줌
-            cnt += 1;
-
-            moim.setMemeber_cnt(cnt);
+            // 주최자 +1 
+            moim.setMemeber_cnt(cnt+1);
         }
 
         return moimList;


### PR DESCRIPTION
예정된 약속 모임 목록관련 현재시간 기준 확정일자가 이미 지나버린 모임이 조회되는 이슈에 대해서 수정합니다.

> 실제 로직 변경 부분
```
.and(qMoim.fixed_date.concat(" ").concat(qMoim.fixed_time).gt(currentTime.toString())))
```

![image](https://github.com/ej522/bside/assets/19955904/02997c74-7700-4cc1-901f-a017371f99db)
