### PR TITLE
Bugfix/participate moim logic fix

### DIFF
--- a/src/main/java/com/example/beside/service/MoimService.java
+++ b/src/main/java/com/example/beside/service/MoimService.java
@@ -70,15 +70,17 @@ public class MoimService {
         moimRepository.makeFriend(moim.getUser().getId(), moimId, user);
 
         // 모임 멤버 추가
-        moimRepository.makeMoimMember(user, moim);
+        MoimMember memberInfo = moimRepository.getMoimMemberByMemberId(moimId, user.getId());
+        if (memberInfo != null)
+            moimRepository.updateMemberAccept(user.getId(), moimId);
+        else
+            moimRepository.makeMoimMember(user, moim);
 
         // 모임 종합 정보 조회
         List<MoimOveralDateDto> moimOveralInfo = moimRepository.getMoimOveralInfo(moimId, null);
 
         // 데이터 결과 가공
-        MoimParticipateInfoDto result = new MoimParticipateInfoDto(moimOveralInfo);
-
-        return result;
+       return new MoimParticipateInfoDto(moimOveralInfo);
     }
 
     // #region [초대받은 모임 참여]


### PR DESCRIPTION
 **[이슈]**
>유저 A가 모임생성시, 기존에 친구로 맺어진 B 를 친구초대로 모임에 초대하고
B 는 푸쉬알람을 눌러서 모임에 참여하는 경우 이슈가 있습니다.

 **[원인]**
> 동일한 모임에 B 가 모임멤버로 2번 INSERT 되는 이슈를 해결합니다. 

**[해결]**
> 프론트 관점에서는 추가적인 로직을 수정하지 않아도 정상적으로 서비스가 되도록 합니다.