### PR TITLE
과거 모임 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
+++ b/src/main/java/com/example/beside/repository/MoimRepositoryImpl.java
@@ -169,7 +169,8 @@ public class MoimRepositoryImpl implements MoimRepository {
                                                 .and(qMoim.fixed_date.isNotNull())
                                                 .and(qMoim.fixed_time.isNotNull())
                                                 .and(qMoimMember.is_accept.eq(true)))
-                                .orderBy(qMoim.fixed_date.desc(), qMoim.fixed_time.desc())
+                                .groupBy(qMoim.id, qMoim.moim_name, qUser.profile_image, qMoim.fixed_date, qMoim.fixed_time, qMoim.user.id)
+                                .orderBy(qMoim.fixed_date.desc(), qMoim.fixed_time.castToNum(Integer.class).desc())
                                 .fetch();
 
                 return result;


### PR DESCRIPTION
멤버가 2명이상일 경우 같은 모임이 중복되어서 조회 되는 경우가 발생
group by를 이용하여 하나만 조회 되도록 함
또, fixed_time의 타입이 string이어서 제대로 정렬 되지 않은 것을 castToNum을 이용하여 integer타입으로 변경 후 정렬