### PR TITLE
친구 초대 로직 추가

### DIFF
--- a/src/test/java/com/example/beside/util/SchedulerTest.java
+++ b/src/test/java/com/example/beside/util/SchedulerTest.java
@@ -6,10 +6,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.example.beside.repository.FcmPushRepository;
 import com.example.beside.service.FcmPushService;
-import com.example.beside.service.MoimService;
-import com.example.beside.service.UserService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -111,7 +108,7 @@ public class SchedulerTest {
         var moimMember = moimRepository.getMoimMemberByMemberId(moimId, findUser2.getId());
         // 상세 모임 일정 등록
         moimRepository.saveSchedule(moimMember, normalMoimMemberTime);
-        Scheduler scheduler = new Scheduler(moimRepository, fcmPushService);
+        Scheduler scheduler = new Scheduler(userRepository, moimRepository, fcmPushService);
 
         // when
         scheduler.fixMoimSchedulering();
@@ -135,7 +132,7 @@ public class SchedulerTest {
         // 모임 생성
         long moimId = moimRepository.makeMoim(findUser, newMoim, moimdate1);
 
-        Scheduler scheduler = new Scheduler(moimRepository, fcmPushService);
+        Scheduler scheduler = new Scheduler(userRepository, moimRepository, fcmPushService);
 
         // when
         scheduler.deleteNotFixedMoim();


### PR DESCRIPTION
**[현 상황]**
기존에 딥링크 초대장을 통해서 모임에 들어온 친구는 서로간의 이미 안다는 전제로 바로 친구를 초대하는 로직이 있습니다.

**[이슈]**
진수는 이미  소연, 승곤과 친구지만, 서로는 친구가 아닌 상황에서, 내가 2명을 강제로 친구초대하게 되면 둘은 영영 친구가 되지 못하는 이슈가 있습니다. 

**[수정 방향]**
친구의 친구여서 서로간의 친구가 아닌 상황에서는, 서로 안다는 전제가 아니기에 모임 확정일자가 정해지고 나서 친구가 정해지도록 
로직을 추가합니다.