### PR TITLE
table 간ondelete 옵션 지정합니다

### DIFF
--- a/src/main/java/com/example/beside/domain/Moim.java
+++ b/src/main/java/com/example/beside/domain/Moim.java
@@ -8,6 +8,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -25,9 +27,11 @@ public class Moim {
     private User user;
 
     @OneToMany(mappedBy = "moim", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<MoimMember> moim_member = new ArrayList<>();
 
     @OneToMany(mappedBy = "moim", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<MoimDate> moim_date = new ArrayList<>();
 
     @Column(length = 100)

--- a/src/main/java/com/example/beside/domain/MoimMember.java
+++ b/src/main/java/com/example/beside/domain/MoimMember.java
@@ -8,6 +8,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -25,6 +27,7 @@ public class MoimMember {
     private Moim moim;
 
     @OneToMany(mappedBy = "moim_member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<MoimMemberTime> moim_member_time = new ArrayList<>();
 
     private Long user_id;

--- a/src/main/java/com/example/beside/domain/User.java
+++ b/src/main/java/com/example/beside/domain/User.java
@@ -3,8 +3,10 @@ package com.example.beside.domain;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.*;
-import lombok.Getter;
 import lombok.*;
 
 @Entity
@@ -19,9 +21,11 @@ public class User {
     private Long id;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Moim> moim;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Friend> friend;
 
     @Column(length = 10)


### PR DESCRIPTION
기존에 Table 간의 연관관계에서 on delete option 이 제대로 작동하지 않아 
데이터 정합성 (삭제) 관리에 어려움이 있었습니다..

해당 부분 on delete 옵션이 제대로 동작하도록 수정합니다.
예시) user 를 삭제하면, 해당 user 와 연관되어 있는 ,friend, moim, moim_date, moim_member , moim_member_time 모두 같이 삭제됩니다. 